### PR TITLE
One planet after sign up

### DIFF
--- a/.database_consistency.yml
+++ b/.database_consistency.yml
@@ -7,3 +7,13 @@ ActiveStorage::Blob:
   enabled: false
 ActiveStorage::VariantRecord:
   enabled: false
+
+# Ignore false positive from Clearance
+User:
+  email:
+    ColumnPresenceChecker:
+      enabled: false
+  index_users_on_remember_token:
+    enabled: false
+  remember_token:
+    enabled: false

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class UsersController < Clearance::UsersController
+  def create
+    @user = user_from_params
+
+    if @user.save
+      sign_in @user
+      redirect_back_or url_after_create
+    else
+      render template: "users/new", status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,11 @@ class UsersController < Clearance::UsersController
   def create
     @user = user_from_params
 
-    if @user.save
+    signed_up = ActiveRecord::Base.transaction do
+      @user.save && @user.planets.create
+    end
+
+    if signed_up
       sign_in @user
       redirect_back_or url_after_create
     else

--- a/app/models/planet.rb
+++ b/app/models/planet.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Planet < ApplicationRecord
+  belongs_to :user
+
+  validates :user, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   include Clearance::User
 
+  has_many :planets, dependent: :destroy
+
   validates :confirmation_token, length: {maximum: 128}, uniqueness: true
   validates :encrypted_password, presence: true, length: {maximum: 128}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,7 @@
 
 class User < ApplicationRecord
   include Clearance::User
+
+  validates :confirmation_token, length: {maximum: 128}, uniqueness: true
+  validates :encrypted_password, presence: true, length: {maximum: 128}
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,4 +1,5 @@
 Clearance.configure do |config|
+  config.routes = false
   config.mailer_sender = "reply@example.com"
   config.rotate_csrf_on_sign_in = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,20 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", :as => :rails_health_check
+
+  resources :passwords, controller: "clearance/passwords", only: [:create, :new]
+  resource :session, controller: "clearance/sessions", only: [:create]
+
+  resources :users, controller: "users", only: [:create] do
+    resource :password,
+      controller: "clearance/passwords",
+      only: [:edit, :update]
+  end
+
+  get "/sign_in" => "clearance/sessions#new", :as => "sign_in"
+  delete "/sign_out" => "clearance/sessions#destroy", :as => "sign_out"
+  get "/sign_up" => "clearance/users#new", :as => "sign_up"
 
   root "pages#index"
 end

--- a/db/migrate/20231013114527_create_planets.rb
+++ b/db/migrate/20231013114527_create_planets.rb
@@ -1,0 +1,9 @@
+class CreatePlanets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :planets do |t|
+      t.references :user, null: false, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231013125651_add_uniqueness_constraint_to_users_email.rb
+++ b/db/migrate/20231013125651_add_uniqueness_constraint_to_users_email.rb
@@ -1,0 +1,6 @@
+class AddUniquenessConstraintToUsersEmail < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :users, :email
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_13_114527) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_13_125651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,7 +29,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_13_114527) do
     t.string "confirmation_token", limit: 128
     t.string "remember_token", limit: 128, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email"
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_06_123141) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_13_114527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "planets", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_planets_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -26,4 +33,5 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_06_123141) do
     t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
   end
 
+  add_foreign_key "planets", "users"
 end

--- a/spec/factories/planets.rb
+++ b/spec/factories/planets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :planet do
+    user
+  end
+end

--- a/spec/models/planet_spec.rb
+++ b/spec/models/planet_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Planet do
+  describe "factory" do
+    it "allows to create a records" do
+      expect { create(:planet) }.not_to raise_error
+    end
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,10 @@ describe User, type: :model do
     end
   end
 
+  describe "associations" do
+    it { is_expected.to have_many(:planets).dependent(:destroy) }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_presence_of(:encrypted_password) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,12 +2,25 @@
 
 require "rails_helper"
 
-describe User do
+describe User, type: :model do
   describe "factory" do
     it "allows to create a records" do
       expect { create(:user) }.not_to raise_error
     end
   end
 
-  it { is_expected.to validate_presence_of(:email) }
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:encrypted_password) }
+
+    it "validates uniqueness of email" do
+      create(:user, email: "example@email.com")
+      user2 = build(:user, email: "example@email.com")
+
+      expect(user2).not_to be_valid
+      expect(user2.errors.full_messages).to(
+        include "Email has already been taken"
+      )
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -16,6 +16,15 @@ describe "POST /users", type: :request do
         expect(User.count).to eq old_user_count + 1
         expect(response).to redirect_to(Clearance.configuration.redirect_url)
       end
+
+      it "creates a planet for the user" do
+        user_attributes = FactoryBot.attributes_for(:user)
+
+        post users_path, params: {user: user_attributes}
+
+        user = User.find_by(email: user_attributes[:email])
+        expect(user.planets.count).to be 1
+      end
     end
 
     context "with invalid attributes" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "POST /users", type: :request do
+  context "when user is signed out" do
+    context "with valid attributes" do
+      it "redirects to the redirect_url" do
+        user_attributes = FactoryBot.attributes_for(:user)
+        old_user_count = User.count
+
+        post users_path, params: {
+          user: user_attributes
+        }
+
+        expect(User.count).to eq old_user_count + 1
+        expect(response).to redirect_to(Clearance.configuration.redirect_url)
+      end
+    end
+
+    context "with invalid attributes" do
+      it "renders the page with error" do
+        user_attributes = FactoryBot.attributes_for(:user, email: nil)
+        old_user_count = User.count
+
+        post users_path, params: {
+          user: user_attributes
+        }
+
+        expect(User.count).to eq old_user_count
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  context "when user is already signed in" do
+    it "redirects to the configured clearance redirect url" do
+      user = create(:user)
+      post(
+        session_path,
+        params: {session: {email: user.email, password: user.password}}
+      )
+
+      post users_path, params: {
+        user: {email: user.email, password: user.password}
+      }
+
+      expect(response).to redirect_to(Clearance.configuration.redirect_url)
+    end
+  end
+end


### PR DESCRIPTION
This creates a a news planets table. By overriding Clearance's `users_controller`, we are able to create and associate a planet to the newly created user.