### PR TITLE
Metal mine upgrade

### DIFF
--- a/app/controllers/planets/metal_mine_upgrades_controller.rb
+++ b/app/controllers/planets/metal_mine_upgrades_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Planets
+  class MetalMineUpgradesController < ApplicationController
+    before_action :require_login
+    before_action :set_planet
+
+    def create
+      form = MetalMineUpgradeForm.new(planet: @planet)
+
+      if form.save
+        flash[:notice] = t(".success")
+      else
+        flash[:alert] = form.errors.full_messages.join(", ")
+      end
+
+      redirect_to root_path
+    end
+
+    private
+
+    def set_planet
+      @planet = current_user.planets.find(params[:planet_id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to root_path
+    end
+  end
+end

--- a/app/controllers/planets/metal_mine_upgrades_controller.rb
+++ b/app/controllers/planets/metal_mine_upgrades_controller.rb
@@ -14,7 +14,7 @@ module Planets
         flash[:alert] = form.errors.full_messages.join(", ")
       end
 
-      redirect_to root_path
+      redirect_to @planet
     end
 
     private

--- a/app/controllers/planets_controller.rb
+++ b/app/controllers/planets_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PlanetsController < ApplicationController
+  before_action :require_login
+
+  def show
+    @planet = Planet.find(params[:id])
+    UpdatePlanetResourcesJob.perform_sync(@planet.id)
+    @planet.reload
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path
+  end
+end

--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module TimeHelper
+  def duration_in_words(duration)
+    ActiveSupport::Duration.build(duration).inspect
+  end
+end

--- a/app/jobs/complete_metal_mine_upgrade_job.rb
+++ b/app/jobs/complete_metal_mine_upgrade_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CompleteMetalMineUpgradeJob
+  include Sidekiq::Job
+
+  def perform(metal_mine_upgrade_id)
+    metal_mine_upgrade = MetalMineUpgrade
+      .in_progress
+      .find(metal_mine_upgrade_id)
+
+    ApplicationRecord.transaction do
+      metal_mine_upgrade.complete!
+      metal_mine_upgrade.planet.update!(
+        metal_mine_level: metal_mine_upgrade.target_level
+      )
+      UpdatePlanetResourcesJob.perform_sync(
+        metal_mine_upgrade.planet_id
+      )
+    end
+  end
+end

--- a/app/models/metal_mine_upgrade.rb
+++ b/app/models/metal_mine_upgrade.rb
@@ -10,6 +10,8 @@ class MetalMineUpgrade < ApplicationRecord
   validates :target_level, presence: true, numericality: {only_integer: true}
   validates :ends_at, presence: true
 
+  scope :in_progress, -> { where(finished: false) }
+
   def self.cost_for_level(level)
     (BASE_COST * CUMULATIVE_FACTOR**(level - 1)).floor
   end

--- a/app/models/metal_mine_upgrade.rb
+++ b/app/models/metal_mine_upgrade.rb
@@ -20,6 +20,10 @@ class MetalMineUpgrade < ApplicationRecord
     (cost_for_level(level) / TIME_FACTOR).round.seconds
   end
 
+  def complete!
+    update!(finished: true)
+  end
+
   def time_remaining
     (ends_at - Time.current).floor
   end

--- a/app/models/metal_mine_upgrade.rb
+++ b/app/models/metal_mine_upgrade.rb
@@ -1,8 +1,20 @@
 # frozen_string_literal: true
 
 class MetalMineUpgrade < ApplicationRecord
+  BASE_COST = 60
+  CUMULATIVE_FACTOR = 4.5
+  TIME_FACTOR = 7.0
+
   belongs_to :planet
 
   validates :target_level, presence: true, numericality: {only_integer: true}
   validates :ends_at, presence: true
+
+  def self.cost_for_level(level)
+    (BASE_COST * CUMULATIVE_FACTOR**(level - 1)).floor
+  end
+
+  def self.duration_for_level(level)
+    (cost_for_level(level) / TIME_FACTOR).round.seconds
+  end
 end

--- a/app/models/metal_mine_upgrade.rb
+++ b/app/models/metal_mine_upgrade.rb
@@ -19,4 +19,8 @@ class MetalMineUpgrade < ApplicationRecord
   def self.duration_for_level(level)
     (cost_for_level(level) / TIME_FACTOR).round.seconds
   end
+
+  def time_remaining
+    (ends_at - Time.current).floor
+  end
 end

--- a/app/models/planet.rb
+++ b/app/models/planet.rb
@@ -3,8 +3,9 @@
 class Planet < ApplicationRecord
   belongs_to :user
 
+  has_many :metal_mine_upgrades, dependent: :destroy, inverse_of: :planet
   has_many :pending_metal_mine_upgrades,
-    -> { where(finished: false) },
+    -> { in_progress },
     class_name: "MetalMineUpgrade",
     dependent: :destroy,
     inverse_of: :planet

--- a/app/models/planet.rb
+++ b/app/models/planet.rb
@@ -25,6 +25,10 @@ class Planet < ApplicationRecord
     metal_production_per_second * 1.hour.to_i
   end
 
+  def next_metal_mine_level
+    metal_mine_level + 1
+  end
+
   private
 
   def time_since_last_resources_update

--- a/app/models/planets/metal_mine_upgrade_form.rb
+++ b/app/models/planets/metal_mine_upgrade_form.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Planets
+  class MetalMineUpgradeForm
+    include ActiveModel::Model
+
+    attr_accessor :planet
+
+    validate :no_pending_upgrades
+    validate :sufficient_resources
+
+    def save
+      return false unless valid?
+
+      ApplicationRecord.transaction do
+        planet.update!(metal: planet.metal - cost)
+        metal_mine_upgrade.save!
+      end
+    end
+
+    private
+
+    def no_pending_upgrades
+      return if planet.pending_metal_mine_upgrades.empty?
+
+      errors.add(:base, :pending_upgrade)
+    end
+
+    def sufficient_resources
+      return if planet.metal >= cost
+
+      errors.add(:base, :insufficient_resources)
+    end
+
+    def metal_mine_upgrade
+      @_metal_mine_upgrade ||= planet.metal_mine_upgrades.build(
+        target_level: target_metal_mine_level,
+        ends_at: ends_at
+      )
+    end
+
+    def current_metal_mine_level
+      planet.metal_mine_level
+    end
+
+    def target_metal_mine_level
+      current_metal_mine_level + 1
+    end
+
+    def ends_at
+      Time.current + MetalMineUpgrade.duration_for_level(target_metal_mine_level)
+    end
+
+    def cost
+      MetalMineUpgrade.cost_for_level(target_metal_mine_level)
+    end
+  end
+end

--- a/app/models/planets/metal_mine_upgrade_form.rb
+++ b/app/models/planets/metal_mine_upgrade_form.rb
@@ -44,7 +44,7 @@ module Planets
     end
 
     def target_metal_mine_level
-      current_metal_mine_level + 1
+      planet.next_metal_mine_level
     end
 
     def ends_at

--- a/app/models/planets/metal_mine_upgrade_form.rb
+++ b/app/models/planets/metal_mine_upgrade_form.rb
@@ -15,6 +15,10 @@ module Planets
       ApplicationRecord.transaction do
         planet.update!(metal: planet.metal - cost)
         metal_mine_upgrade.save!
+        CompleteMetalMineUpgradeJob.perform_at(
+          metal_mine_upgrade.ends_at,
+          metal_mine_upgrade.id
+        )
       end
     end
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,18 +3,11 @@
     <% current_user.planets.each do |planet| %>
       <div class="inline-block mt-4">
         <%= image_tag "pluto.png", class: "inline-block w-40" %>
-        <h3 class="text-2xl"><%= t("planets.homeworld") %></h3>
-        <h4 class="text-xl">
-          <%= Planet.human_attribute_name(:metal) %> -
-          <%= t("planets.level", level: planet.metal_mine_level) %>
-          <span class="text-sm">
-            (<%= t("planets.metal_production_hourly_rate", rate: planet.metal_production_hourly_rate) %>)
-          </span>
-          <span class="text-sm">
-            <%= link_to t("planets.upgrade"), planet_metal_mine_upgrades_path(planet), data: {turbo_method: "post"}, class: "text-blue-800 underline hover:no-underline" %>
-          </span>
-        </h4>
-        <p><%= planet.metal %></p>
+        <h3 class="text-2xl">
+          <%= link_to planet, class: "text-blue-800 underline hover:no-underline" do %>
+            <%= t("planets.homeworld") %>
+          <% end %>
+        </h3>
       </div>
     <% end %>
   </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -10,6 +10,9 @@
           <span class="text-sm">
             (<%= t("planets.metal_production_hourly_rate", rate: planet.metal_production_hourly_rate) %>)
           </span>
+          <span class="text-sm">
+            <%= link_to t("planets.upgrade"), planet_metal_mine_upgrades_path(planet), data: {turbo_method: "post"}, class: "text-blue-800 underline hover:no-underline" %>
+          </span>
         </h4>
         <p><%= planet.metal %></p>
       </div>

--- a/app/views/planets/_upgrade.html.erb
+++ b/app/views/planets/_upgrade.html.erb
@@ -1,0 +1,27 @@
+<p>
+  <span class="text-sm">
+    <% if Planets::MetalMineUpgradeForm.new(planet: @planet).valid? %>
+      <%= link_to(
+            t("planets.upgrade"),
+            planet_metal_mine_upgrades_path(@planet),
+            data: {turbo_method: "post"},
+            class: "text-blue-800 underline hover:no-underline"
+          ) %>
+      &rarr;
+      <%= t(
+            "utils.resources.metal",
+            metal: number_with_delimiter(
+              MetalMineUpgrade.cost_for_level(@planet.next_metal_mine_level)
+            )
+          ) %> -
+      <%= duration_in_words MetalMineUpgrade.duration_for_level(@planet.next_metal_mine_level) %>
+    <% elsif pending_upgrade = @planet.pending_metal_mine_upgrades.last %>
+      <s><%= t("planets.upgrade") %></s> -
+      <%= t(
+            "planets.pending_upgrade",
+            target_level: pending_upgrade.target_level,
+            time_remaining: duration_in_words(pending_upgrade.time_remaining)
+          ) %>
+    <% end %>
+  </span>
+</p>

--- a/app/views/planets/show.html.erb
+++ b/app/views/planets/show.html.erb
@@ -12,28 +12,5 @@
 
   <p><%= number_with_delimiter @planet.metal %></p>
 
-  <p>
-    <% if Planets::MetalMineUpgradeForm.new(planet: @planet).valid? %>
-      <span class="text-sm">
-        <%= link_to(
-              t("planets.upgrade"),
-              planet_metal_mine_upgrades_path(@planet),
-              data: {turbo_method: "post"},
-              class: "text-blue-800 underline hover:no-underline"
-            ) %>
-        &rarr;
-        <%= t(
-              "utils.resources.metal",
-              metal: number_with_delimiter(
-                MetalMineUpgrade.cost_for_level(@planet.next_metal_mine_level)
-              )
-            ) %> -
-        <%= ActiveSupport::Duration.build(
-              MetalMineUpgrade.duration_for_level(@planet.next_metal_mine_level)
-            ).inspect %>
-      </span>
-    <% else %>
-      <s><%= t("planets.upgrade") %></s>
-    <% end %>
-  </p>
+  <%= render "upgrade" %>
 </div>

--- a/app/views/planets/show.html.erb
+++ b/app/views/planets/show.html.erb
@@ -1,20 +1,39 @@
 <div class="inline-block mt-4">
   <%= image_tag "pluto.png", class: "inline-block w-40" %>
   <h3 class="text-2xl"><%= t("planets.homeworld") %></h3>
+
   <h4 class="text-xl">
     <%= Planet.human_attribute_name(:metal) %> -
     <%= t("planets.level", level: @planet.metal_mine_level) %>
     <span class="text-sm">
       (<%= t("planets.metal_production_hourly_rate", rate: @planet.metal_production_hourly_rate) %>)
     </span>
-    <span class="text-sm">
-      <%= link_to(
-            t("planets.upgrade"),
-            planet_metal_mine_upgrades_path(@planet),
-            data: {turbo_method: "post"},
-            class: "text-blue-800 underline hover:no-underline"
-          ) %>
-    </span>
   </h4>
-  <p><%= @planet.metal %></p>
+
+  <p><%= number_with_delimiter @planet.metal %></p>
+
+  <p>
+    <% if Planets::MetalMineUpgradeForm.new(planet: @planet).valid? %>
+      <span class="text-sm">
+        <%= link_to(
+              t("planets.upgrade"),
+              planet_metal_mine_upgrades_path(@planet),
+              data: {turbo_method: "post"},
+              class: "text-blue-800 underline hover:no-underline"
+            ) %>
+        &rarr;
+        <%= t(
+              "utils.resources.metal",
+              metal: number_with_delimiter(
+                MetalMineUpgrade.cost_for_level(@planet.next_metal_mine_level)
+              )
+            ) %> -
+        <%= ActiveSupport::Duration.build(
+              MetalMineUpgrade.duration_for_level(@planet.next_metal_mine_level)
+            ).inspect %>
+      </span>
+    <% else %>
+      <s><%= t("planets.upgrade") %></s>
+    <% end %>
+  </p>
 </div>

--- a/app/views/planets/show.html.erb
+++ b/app/views/planets/show.html.erb
@@ -1,0 +1,20 @@
+<div class="inline-block mt-4">
+  <%= image_tag "pluto.png", class: "inline-block w-40" %>
+  <h3 class="text-2xl"><%= t("planets.homeworld") %></h3>
+  <h4 class="text-xl">
+    <%= Planet.human_attribute_name(:metal) %> -
+    <%= t("planets.level", level: @planet.metal_mine_level) %>
+    <span class="text-sm">
+      (<%= t("planets.metal_production_hourly_rate", rate: @planet.metal_production_hourly_rate) %>)
+    </span>
+    <span class="text-sm">
+      <%= link_to(
+            t("planets.upgrade"),
+            planet_metal_mine_upgrades_path(@planet),
+            data: {turbo_method: "post"},
+            class: "text-blue-800 underline hover:no-underline"
+          ) %>
+    </span>
+  </h4>
+  <p><%= @planet.metal %></p>
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,4 +61,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.middleware.use Clearance::BackDoor
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,3 +22,4 @@ en:
       create:
         success: Metal mine upgrade started
     metal_production_hourly_rate: "%{rate}/hr"
+    upgrade: Upgrade

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
       create:
         success: Metal mine upgrade started
     metal_production_hourly_rate: "%{rate}/hr"
+    pending_upgrade: "Upgrade to level %{target_level} finished in %{time_remaining}"
     upgrade: Upgrade
   utils:
     resources:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,3 +23,6 @@ en:
         success: Metal mine upgrade started
     metal_production_hourly_rate: "%{rate}/hr"
     upgrade: Upgrade
+  utils:
+    resources:
+      metal: "%{metal} Metal"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,12 @@
 en:
+  activemodel:
+    errors:
+      models:
+        planets/metal_mine_upgrade_form:
+          attributes:
+            base:
+              insufficient_resources: Insufficient resources
+              pending_upgrade: An upgrade is already in progress
   activerecord:
     attributes:
       planet:
@@ -10,4 +18,7 @@ en:
   planets:
     homeworld: Homeworld
     level: lvl %{level}
+    metal_mine_upgrades:
+      create:
+        success: Metal mine upgrade started
     metal_production_hourly_rate: "%{rate}/hr"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,8 @@ Rails.application.routes.draw do
   get "/sign_up" => "clearance/users#new", :as => "sign_up"
 
   root "pages#index"
+
+  resources :planets, only: [] do
+    resources :metal_mine_upgrades, only: [:create], module: :planets
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   root "pages#index"
 
-  resources :planets, only: [] do
+  resources :planets, only: [:show] do
     resources :metal_mine_upgrades, only: [:create], module: :planets
   end
 end

--- a/spec/factories/metal_mine_upgrades.rb
+++ b/spec/factories/metal_mine_upgrades.rb
@@ -5,5 +5,13 @@ FactoryBot.define do
     planet
     target_level { 2 }
     ends_at { 1.minute.from_now }
+
+    trait :finished do
+      finished { true }
+    end
+
+    trait :in_progress do
+      finished { false }
+    end
   end
 end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -3,27 +3,20 @@
 require "rails_helper"
 
 describe "the home page" do
-  describe "planet's resources" do
-    it "shows updated values" do
-      travel_to Time.zone.local(2023, 10, 22, 12, 0, 0) do
-        user = create(:user, password: "password")
-        create(
-          :planet,
-          user: user,
-          metal: 0,
-          metal_basic_income: 10,
-          metal_mine_level: 2,
-          resources_updated_at: Time.current
-        )
+  it "shows the user's planets" do
+    user = create(:user, password: "password")
+    create(
+      :planet,
+      user: user,
+      metal: 0,
+      metal_basic_income: 10,
+      metal_mine_level: 2,
+      resources_updated_at: Time.current
+    )
 
-        sign_in_with(user.email, "password")
-      end
+    sign_in_with(user.email, "password")
+    visit root_path
 
-      travel_to Time.zone.local(2023, 10, 22, 13, 0, 0) do
-        visit root_path
-
-        expect(page).to have_content(72000)
-      end
-    end
+    expect(page).to have_link I18n.t("planets.homeworld")
   end
 end

--- a/spec/features/planets_spec.rb
+++ b/spec/features/planets_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Planets" do
+  describe "planet's resources" do
+    it "shows updated values" do
+      travel_to Time.zone.local(2023, 10, 22, 12, 0, 0) do
+        user = create(:user, password: "password")
+        create(
+          :planet,
+          user: user,
+          metal: 0,
+          metal_basic_income: 10,
+          metal_mine_level: 2,
+          resources_updated_at: Time.current
+        )
+
+        sign_in_with(user.email, "password")
+      end
+
+      travel_to Time.zone.local(2023, 10, 22, 13, 0, 0) do
+        visit root_path
+        click_link I18n.t("planets.homeworld")
+
+        expect(page).to have_content(72000)
+      end
+    end
+  end
+end

--- a/spec/features/planets_spec.rb
+++ b/spec/features/planets_spec.rb
@@ -27,4 +27,26 @@ describe "Planets" do
       end
     end
   end
+
+  describe "planet's metal mine upgrades" do
+    it "enables the user to upgrade the metal mine level" do
+      travel_to Time.zone.local(2023, 10, 22, 12, 30, 0) do
+        user = create(:user, password: "password")
+        create(:planet, user: user, metal_mine_level: 1, metal: 10_000)
+        sign_in_with(user.email, "password")
+
+        visit root_path
+        click_link I18n.t("planets.homeworld")
+
+        expect(page).to have_content("Upgrade")
+        expect(page).to have_content("270 Metal")
+        expect(page).to have_content("39 seconds")
+
+        click_link "Upgrade"
+
+        expect(page).to have_content("9,730")
+        expect(page).to have_content("Upgrade to level 2 finished in 39 seconds")
+      end
+    end
+  end
 end

--- a/spec/helpers/time_helper_spec.rb
+++ b/spec/helpers/time_helper_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TimeHelper do
+  describe "#duration_in_words" do
+    it "returns the duration in words" do
+      duration = 1.hour + 1.minute + 1.second
+
+      expect(duration_in_words(duration)).to(
+        eq("1 hour, 1 minute, and 1 second")
+      )
+    end
+  end
+end

--- a/spec/jobs/complete_metal_mine_upgrade_job_spec.rb
+++ b/spec/jobs/complete_metal_mine_upgrade_job_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CompleteMetalMineUpgradeJob do
+  it "marks an upgrade as finished" do
+    Sidekiq::Testing.inline! do
+      metal_mine_upgrade = create(:metal_mine_upgrade, :in_progress)
+
+      described_class.perform_async(metal_mine_upgrade.id)
+
+      expect(metal_mine_upgrade.reload).to be_finished
+    end
+  end
+
+  it "upgrades the associated metal mine's level" do
+    Sidekiq::Testing.inline! do
+      planet = create(:planet, metal_mine_level: 1)
+      metal_mine_upgrade = create(
+        :metal_mine_upgrade,
+        :in_progress,
+        planet: planet,
+        target_level: 2
+      )
+
+      described_class.perform_async(metal_mine_upgrade.id)
+
+      expect(planet.reload.metal_mine_level).to eq(2)
+    end
+  end
+
+  it "triggers the planet's resources update" do
+    Sidekiq::Testing.inline! do
+      allow(UpdatePlanetResourcesJob).to receive(:perform_sync)
+      metal_mine_upgrade = create(:metal_mine_upgrade, :in_progress)
+
+      described_class.perform_async(metal_mine_upgrade.id)
+
+      expect(UpdatePlanetResourcesJob).to(
+        have_received(:perform_sync).with(metal_mine_upgrade.planet.id)
+      )
+    end
+  end
+
+  context "when the completion fails" do
+    it "doesn't complete and doesn't upgrade" do
+      planet = create(:planet, metal_mine_level: 1)
+      metal_mine_upgrade = create(
+        :metal_mine_upgrade,
+        :in_progress,
+        planet: planet,
+        target_level: 2
+      )
+      allow(metal_mine_upgrade).to(
+        receive(:complete!).and_raise(ActiveRecord::RecordInvalid)
+      )
+
+      described_class.perform_async(metal_mine_upgrade.id)
+
+      expect(metal_mine_upgrade.reload).not_to be_finished
+      expect(planet.reload.metal_mine_level).to eq(1)
+    end
+  end
+end

--- a/spec/models/metal_mine_upgrade_spec.rb
+++ b/spec/models/metal_mine_upgrade_spec.rb
@@ -18,4 +18,34 @@ describe MetalMineUpgrade do
     it { is_expected.to validate_numericality_of(:target_level).only_integer }
     it { is_expected.to validate_presence_of(:ends_at) }
   end
+
+  describe "::cost_for_level" do
+    [
+      {level: 2, cost: 270},
+      {level: 3, cost: 1_215},
+      {level: 4, cost: 5_467},
+      {level: 5, cost: 24_603},
+      {level: 6, cost: 110_716}
+    ].each do |test_case|
+      it "returns the right cost for the level #{test_case[:level]}" do
+        cost = described_class.cost_for_level(test_case[:level])
+        expect(cost).to eq(test_case[:cost])
+      end
+    end
+  end
+
+  describe "::duration_for_level" do
+    [
+      {level: 2, duration: 39.seconds},
+      {level: 3, duration: 174.seconds},
+      {level: 4, duration: 781.seconds},
+      {level: 5, duration: 3_515.seconds},
+      {level: 6, duration: 15_817.seconds}
+    ].each do |test_case|
+      it "returns the right duration for the level #{test_case[:level]}" do
+        duration = described_class.duration_for_level(test_case[:level])
+        expect(duration).to eq(test_case[:duration])
+      end
+    end
+  end
 end

--- a/spec/models/metal_mine_upgrade_spec.rb
+++ b/spec/models/metal_mine_upgrade_spec.rb
@@ -48,4 +48,14 @@ describe MetalMineUpgrade do
       end
     end
   end
+
+  describe "#time_remaining" do
+    it "returns the time remaining until the upgrade is finished" do
+      travel_to Time.zone.local(2023, 10, 22, 12, 0, 0) do
+        upgrade = create(:metal_mine_upgrade, ends_at: 1.hour.from_now)
+
+        expect(upgrade.time_remaining).to eq(1.hour)
+      end
+    end
+  end
 end

--- a/spec/models/metal_mine_upgrade_spec.rb
+++ b/spec/models/metal_mine_upgrade_spec.rb
@@ -49,6 +49,16 @@ describe MetalMineUpgrade do
     end
   end
 
+  describe "#complete!" do
+    it "updates a record from unfinished to finished" do
+      record = create(:metal_mine_upgrade, :in_progress)
+
+      expect { record.complete! }.to(
+        change(record, :finished).from(false).to(true)
+      )
+    end
+  end
+
   describe "#time_remaining" do
     it "returns the time remaining until the upgrade is finished" do
       travel_to Time.zone.local(2023, 10, 22, 12, 0, 0) do

--- a/spec/models/planet_spec.rb
+++ b/spec/models/planet_spec.rb
@@ -42,4 +42,12 @@ describe Planet do
       expect(planet.metal_production_hourly_rate).to eq(72000)
     end
   end
+
+  describe "#next_metal_mine_level" do
+    it "returns the next metal mine level" do
+      planet = create(:planet, metal_mine_level: 2)
+
+      expect(planet.next_metal_mine_level).to eq(3)
+    end
+  end
 end

--- a/spec/models/planets/metal_mine_upgrade_form_spec.rb
+++ b/spec/models/planets/metal_mine_upgrade_form_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Planets::MetalMineUpgradeForm do
+  describe "#valid?" do
+    context "when all conditions are met" do
+      it "returns true" do
+        stub_metal_mine_upgrade
+        planet = build_stubbed(:planet, metal: 100)
+        form = described_class.new(planet: planet)
+
+        expect(form.valid?).to be true
+      end
+    end
+
+    context "when there is a pending upgrade" do
+      it "returns false" do
+        stub_metal_mine_upgrade
+        planet = create(:planet, metal: 100)
+        create(:metal_mine_upgrade, :in_progress, planet: planet)
+        form = described_class.new(planet: planet)
+
+        expect(form.valid?).to be false
+        expect(form.errors).to be_added(:base, :pending_upgrade)
+      end
+    end
+
+    context "when there are insufficient resources" do
+      it "returns false" do
+        stub_metal_mine_upgrade(cost: 150)
+        planet = build_stubbed(:planet, metal: 100)
+        form = described_class.new(planet: planet)
+
+        expect(form.valid?).to be false
+        expect(form.errors).to be_added(:base, :insufficient_resources)
+      end
+    end
+  end
+
+  describe "#save" do
+    it "creates a metal mine upgrade" do
+      stub_metal_mine_upgrade
+      planet = create(:planet, metal: 100)
+      form = described_class.new(planet: planet)
+
+      expect { form.save }.to change(planet.pending_metal_mine_upgrades, :count).by(1)
+    end
+
+    it "deducts the cost from the planet" do
+      stub_metal_mine_upgrade
+      planet = create(:planet, metal: 100)
+      form = described_class.new(planet: planet)
+
+      expect { form.save }.to change { planet.reload.metal }.by(-50)
+    end
+
+    context "when the form is invalid" do
+      it "returns false" do
+        stub_metal_mine_upgrade(cost: 150)
+        planet = build_stubbed(:planet, metal: 100)
+        form = described_class.new(planet: planet)
+
+        expect(form.save).to be false
+      end
+    end
+
+    context "when it fails" do
+      it "doesn't cost resources to the planet and doesn't start the upgrade" do
+        stub_metal_mine_upgrade
+        planet = create(:planet, metal: 100)
+        form = described_class.new(planet: planet)
+        allow(planet).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+
+        form.save
+      rescue ActiveRecord::RecordInvalid
+        expect(planet.reload.metal).to eq(100)
+        expect(planet.pending_metal_mine_upgrades.count).to eq(0)
+      end
+    end
+  end
+
+  def stub_metal_mine_upgrade(cost: 50)
+    allow(MetalMineUpgrade).to receive(:cost_for_level).and_return(cost)
+  end
+end

--- a/spec/requests/planets/metal_mine_upgrades_spec.rb
+++ b/spec/requests/planets/metal_mine_upgrades_spec.rb
@@ -11,7 +11,7 @@ describe "POST /planets/:planet_id/metal_mine_upgrades" do
 
       post planet_metal_mine_upgrades_path(planet, as: user)
 
-      expect(response).to redirect_to root_path
+      expect(response).to redirect_to planet
       expect(flash[:notice]).to(
         eq I18n.t("planets.metal_mine_upgrades.create.success")
       )
@@ -28,7 +28,7 @@ describe "POST /planets/:planet_id/metal_mine_upgrades" do
 
         post planet_metal_mine_upgrades_path(planet, as: user)
 
-        expect(response).to redirect_to root_path
+        expect(response).to redirect_to planet
         expect(flash[:alert]).to eq "Something went wrong"
       end
     end

--- a/spec/requests/planets/metal_mine_upgrades_spec.rb
+++ b/spec/requests/planets/metal_mine_upgrades_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "POST /planets/:planet_id/metal_mine_upgrades" do
+  context "when user is signed in" do
+    it "redirects with a successful flash message" do
+      stub_metal_mine_upgrade_form(successful: true)
+      user = create(:user)
+      planet = create(:planet, user: user, metal_mine_level: 1)
+
+      post planet_metal_mine_upgrades_path(planet, as: user)
+
+      expect(response).to redirect_to root_path
+      expect(flash[:notice]).to(
+        eq I18n.t("planets.metal_mine_upgrades.create.success")
+      )
+    end
+
+    context "when the form is invalid" do
+      it "redirects with an alert flash message" do
+        stub_metal_mine_upgrade_form(
+          successful: false,
+          error: "Something went wrong"
+        )
+        user = create(:user)
+        planet = create(:planet, user: user, metal_mine_level: 1)
+
+        post planet_metal_mine_upgrades_path(planet, as: user)
+
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq "Something went wrong"
+      end
+    end
+
+    context "when the planet is not found" do
+      it "redirects to the root page" do
+        user = create(:user)
+
+        post planet_metal_mine_upgrades_path(0, as: user)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  context "when user is signed out" do
+    it "redirects to the sign in page" do
+      user = create(:user)
+      planet = create(:planet, user: user)
+
+      post planet_metal_mine_upgrades_path(planet)
+
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
+
+  def stub_metal_mine_upgrade_form(successful: true, error: nil)
+    form = instance_double(Planets::MetalMineUpgradeForm, save: successful)
+    if error.present?
+      full_messages = Struct.new(:full_messages).new([error])
+      allow(form).to receive(:errors).and_return(full_messages)
+    end
+    allow(Planets::MetalMineUpgradeForm).to receive(:new).and_return(form)
+  end
+end

--- a/spec/requests/planets_spec.rb
+++ b/spec/requests/planets_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "GET /planets/:id" do
+  context "when user is signed in" do
+    it "is successful" do
+      user = create(:user)
+      planet = create(:planet, user: user)
+
+      get planet_path(planet, as: user)
+
+      expect(response).to be_successful
+    end
+
+    context "when the planet is not found" do
+      it "redirects to the root page" do
+        user = create(:user)
+
+        get planet_path(0, as: user)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  context "when user is signed out" do
+    it "redirects to the sign in page" do
+      user = create(:user)
+      planet = create(:planet, user: user)
+
+      get planet_path(planet)
+
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
+end


### PR DESCRIPTION
Upgrading a metal mine leads to an increased metal income. One can start a metal mine upgrade from the newly implemented planet's page, where the conditions are displayed, such as the cost and time to complete the upgrade.

Upgrading requires resources and time. The `MetalMineUpgrade` model supports the calculations of cost and duration for a given level upgrade. Cost and duration increase exponentially level after level.

Only one upgrade can be started at a time.
If an upgrade is rejected (missing resources, another one still in progress), the error is displayed to the user as a flash message.

Once the upgrade is started, it's not possible to start another upgrade. The pending upgrade's remaining time is showed and the cost of the upgrade is deducted from the planet's resources.

A background job is scheduled for the end time, so that the completion logic is immediately executed. Completing an upgrade marks it as finished, update the metal mine's level and update the planet's resources so that the last update already uses the new income.